### PR TITLE
Super fast XOR

### DIFF
--- a/websocket_test.go
+++ b/websocket_test.go
@@ -776,6 +776,7 @@ func benchConn(b *testing.B, echo, stream bool, size int) {
 func BenchmarkConn(b *testing.B) {
 	sizes := []int{
 		2,
+		16,
 		32,
 		512,
 		4096,

--- a/xor.go
+++ b/xor.go
@@ -13,10 +13,10 @@ import (
 // to be used for masking in the key. This is so that
 // unmasking can be performed without the entire frame.
 func fastXOR(key [4]byte, keyPos int, b []byte) int {
-	// If the payload is greater than 16 bytes, then it's worth
+	// If the payload is greater than or equal to 16 bytes, then it's worth
 	// masking 8 bytes at a time.
 	// Optimization from https://github.com/golang/go/issues/31586#issuecomment-485530859
-	if len(b) > 16 {
+	if len(b) >= 16 {
 		// We first create a key that is 8 bytes long
 		// and is aligned on the position correctly.
 		var alignedKey [8]byte
@@ -24,6 +24,86 @@ func fastXOR(key [4]byte, keyPos int, b []byte) int {
 			alignedKey[i] = key[(i+keyPos)&3]
 		}
 		k := binary.LittleEndian.Uint64(alignedKey[:])
+
+		// Then we xor until b is less than 128 bytes.
+		for len(b) >= 128 {
+			v := binary.LittleEndian.Uint64(b)
+			binary.LittleEndian.PutUint64(b, v^k)
+			v = binary.LittleEndian.Uint64(b[8:])
+			binary.LittleEndian.PutUint64(b[8:], v^k)
+			v = binary.LittleEndian.Uint64(b[16:])
+			binary.LittleEndian.PutUint64(b[16:], v^k)
+			v = binary.LittleEndian.Uint64(b[24:])
+			binary.LittleEndian.PutUint64(b[24:], v^k)
+			v = binary.LittleEndian.Uint64(b[32:])
+			binary.LittleEndian.PutUint64(b[32:], v^k)
+			v = binary.LittleEndian.Uint64(b[40:])
+			binary.LittleEndian.PutUint64(b[40:], v^k)
+			v = binary.LittleEndian.Uint64(b[48:])
+			binary.LittleEndian.PutUint64(b[48:], v^k)
+			v = binary.LittleEndian.Uint64(b[56:])
+			binary.LittleEndian.PutUint64(b[56:], v^k)
+			v = binary.LittleEndian.Uint64(b[64:])
+			binary.LittleEndian.PutUint64(b[64:], v^k)
+			v = binary.LittleEndian.Uint64(b[72:])
+			binary.LittleEndian.PutUint64(b[72:], v^k)
+			v = binary.LittleEndian.Uint64(b[80:])
+			binary.LittleEndian.PutUint64(b[80:], v^k)
+			v = binary.LittleEndian.Uint64(b[88:])
+			binary.LittleEndian.PutUint64(b[88:], v^k)
+			v = binary.LittleEndian.Uint64(b[96:])
+			binary.LittleEndian.PutUint64(b[96:], v^k)
+			v = binary.LittleEndian.Uint64(b[104:])
+			binary.LittleEndian.PutUint64(b[104:], v^k)
+			v = binary.LittleEndian.Uint64(b[112:])
+			binary.LittleEndian.PutUint64(b[112:], v^k)
+			v = binary.LittleEndian.Uint64(b[120:])
+			binary.LittleEndian.PutUint64(b[120:], v^k)
+			b = b[128:]
+		}
+
+		// Then we xor until b is less than 64 bytes.
+		for len(b) >= 64 {
+			v := binary.LittleEndian.Uint64(b)
+			binary.LittleEndian.PutUint64(b, v^k)
+			v = binary.LittleEndian.Uint64(b[8:])
+			binary.LittleEndian.PutUint64(b[8:], v^k)
+			v = binary.LittleEndian.Uint64(b[16:])
+			binary.LittleEndian.PutUint64(b[16:], v^k)
+			v = binary.LittleEndian.Uint64(b[24:])
+			binary.LittleEndian.PutUint64(b[24:], v^k)
+			v = binary.LittleEndian.Uint64(b[32:])
+			binary.LittleEndian.PutUint64(b[32:], v^k)
+			v = binary.LittleEndian.Uint64(b[40:])
+			binary.LittleEndian.PutUint64(b[40:], v^k)
+			v = binary.LittleEndian.Uint64(b[48:])
+			binary.LittleEndian.PutUint64(b[48:], v^k)
+			v = binary.LittleEndian.Uint64(b[56:])
+			binary.LittleEndian.PutUint64(b[56:], v^k)
+			b = b[64:]
+		}
+
+		// Then we xor until b is less than 32 bytes.
+		for len(b) >= 32 {
+			v := binary.LittleEndian.Uint64(b)
+			binary.LittleEndian.PutUint64(b, v^k)
+			v = binary.LittleEndian.Uint64(b[8:])
+			binary.LittleEndian.PutUint64(b[8:], v^k)
+			v = binary.LittleEndian.Uint64(b[16:])
+			binary.LittleEndian.PutUint64(b[16:], v^k)
+			v = binary.LittleEndian.Uint64(b[24:])
+			binary.LittleEndian.PutUint64(b[24:], v^k)
+			b = b[32:]
+		}
+
+		// Then we xor until b is less than 16 bytes.
+		for len(b) >= 16 {
+			v := binary.LittleEndian.Uint64(b)
+			binary.LittleEndian.PutUint64(b, v^k)
+			v = binary.LittleEndian.Uint64(b[8:])
+			binary.LittleEndian.PutUint64(b[8:], v^k)
+			b = b[16:]
+		}
 
 		// Then we xor until b is less than 8 bytes.
 		for len(b) >= 8 {

--- a/xor_test.go
+++ b/xor_test.go
@@ -36,6 +36,7 @@ func basixXOR(maskKey [4]byte, pos int, b []byte) int {
 func BenchmarkXOR(b *testing.B) {
 	sizes := []int{
 		2,
+		16,
 		32,
 		512,
 		4096,


### PR DESCRIPTION
Closes #76

```
benchmark                      old ns/op     new ns/op     delta
BenchmarkXOR/2/basic-2         5.43          5.46          +0.55%
BenchmarkXOR/2/fast-2          6.42          6.39          -0.47%
BenchmarkXOR/16/basic-2        17.0          17.1          +0.59%
BenchmarkXOR/16/fast-2         17.7          16.6          -6.21%
BenchmarkXOR/32/basic-2        30.6          30.7          +0.33%
BenchmarkXOR/32/fast-2         19.3          17.8          -7.77%
BenchmarkXOR/512/basic-2       448           445           -0.67%
BenchmarkXOR/512/fast-2        98.7          61.2          -37.99%
BenchmarkXOR/4096/basic-2      3487          3498          +0.32%
BenchmarkXOR/4096/fast-2       697           379           -45.62%
BenchmarkXOR/16384/basic-2     13894         13952         +0.42%
BenchmarkXOR/16384/fast-2      2738          1475          -46.13%

benchmark                      old MB/s     new MB/s     speedup
BenchmarkXOR/2/basic-2         368.43       365.98       0.99x
BenchmarkXOR/2/fast-2          311.55       313.15       1.01x
BenchmarkXOR/16/basic-2        941.21       935.48       0.99x
BenchmarkXOR/16/fast-2         901.42       962.22       1.07x
BenchmarkXOR/32/basic-2        1044.65      1041.27      1.00x
BenchmarkXOR/32/fast-2         1654.63      1802.62      1.09x
BenchmarkXOR/512/basic-2       1142.53      1149.90      1.01x
BenchmarkXOR/512/fast-2        5188.32      8368.92      1.61x
BenchmarkXOR/4096/basic-2      1174.33      1170.82      1.00x
BenchmarkXOR/4096/fast-2       5875.49      10802.77     1.84x
BenchmarkXOR/16384/basic-2     1179.14      1174.24      1.00x
BenchmarkXOR/16384/fast-2      5982.73      11104.28     1.86x
```