### PR TITLE
Problem: NetConn wrapper kept canceling context

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -134,11 +134,23 @@ func (c *netConn) SetDeadline(t time.Time) error {
 }
 
 func (c *netConn) SetWriteDeadline(t time.Time) error {
-	c.writeTimer.Reset(t.Sub(time.Now()))
+	if t.IsZero() {
+		if !c.writeTimer.Stop() {
+			<-c.writeTimer.C
+		}
+	} else {
+		c.writeTimer.Reset(t.Sub(time.Now()))
+	}
 	return nil
 }
 
 func (c *netConn) SetReadDeadline(t time.Time) error {
-	c.readTimer.Reset(t.Sub(time.Now()))
+	if t.IsZero() {
+		if !c.readTimer.Stop() {
+			<-c.readTimer.C
+		}
+	} else {
+		c.readTimer.Reset(t.Sub(time.Now()))
+	}
 	return nil
 }

--- a/websocket_test.go
+++ b/websocket_test.go
@@ -130,7 +130,9 @@ func TestHandshake(t *testing.T) {
 				nc := websocket.NetConn(c)
 				defer nc.Close()
 
-				nc.SetWriteDeadline(time.Now().Add(time.Second * 15))
+				nc.SetWriteDeadline(time.Time{})
+				time.Sleep(1)
+				nc.SetWriteDeadline(time.Now().Add(time.Second * 14))
 
 				for i := 0; i < 3; i++ {
 					_, err = nc.Write([]byte("hello"))
@@ -153,7 +155,9 @@ func TestHandshake(t *testing.T) {
 				nc := websocket.NetConn(c)
 				defer nc.Close()
 
-				nc.SetReadDeadline(time.Now().Add(time.Second * 15))
+				nc.SetReadDeadline(time.Time{})
+				time.Sleep(1)
+				nc.SetReadDeadline(time.Now().Add(time.Second * 14))
 
 				read := func() error {
 					p := make([]byte, len("hello"))


### PR DESCRIPTION
Solution: Accept the zero time as a special case when setting
deadlines. Somehow, this function gets called without a time and thus
would previously Reset the timer to no time at all, thus expediting the
call to cancel the context.

Would close #111 