### PR TITLE
Update server example for 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ For a production quality example that shows off the full API, see the [echo exam
 
 ```go
 http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
-	c, err := websocket.Accept(w, r, nil)
+	var opts websocket.AcceptOptions
+	c, err := websocket.Accept(w, r, opts)
 	if err != nil {
 		// ...
 	}


### PR DESCRIPTION
The API must have changed. `nil` is not valid as options to `websocket.Accept` in 1.4.0.