### PR TITLE
Improve usage of math/rand versus crypto/rand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,18 @@ jobs:
     container: docker://nhooyr/websocket-ci@sha256:b6331f8f64803c8b1bbd2a0ee9e2547317e0de2348bccd9c8dbcc1d88ff5747f
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
       - run: ./ci/fmt.sh
   lint:
     runs-on: ubuntu-latest
     container: docker://nhooyr/websocket-ci@sha256:b6331f8f64803c8b1bbd2a0ee9e2547317e0de2348bccd9c8dbcc1d88ff5747f
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
       - run: ./ci/lint.sh
   test:
     runs-on: ubuntu-latest
     container: docker://nhooyr/websocket-ci@sha256:b6331f8f64803c8b1bbd2a0ee9e2547317e0de2348bccd9c8dbcc1d88ff5747f
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
       - run: ./ci/test.sh
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -33,6 +27,4 @@ jobs:
     container: docker://nhooyr/websocket-ci@sha256:b6331f8f64803c8b1bbd2a0ee9e2547317e0de2348bccd9c8dbcc1d88ff5747f
     steps:
       - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
       - run: ./ci/wasm.sh

--- a/assert_test.go
+++ b/assert_test.go
@@ -6,12 +6,17 @@ import (
 	"math/rand"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 
 	"nhooyr.io/websocket"
 	"nhooyr.io/websocket/wsjson"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 // https://github.com/google/go-cmp/issues/40#issuecomment-328615283
 func cmpDiff(exp, act interface{}) string {

--- a/ci/wasm.sh
+++ b/ci/wasm.sh
@@ -25,7 +25,7 @@ go install github.com/agnivade/wasmbrowsertest
 export WS_ECHO_SERVER_URL
 GOOS=js GOARCH=wasm go test -exec=wasmbrowsertest ./...
 
-kill "$wsjstestPID"
+kill "$wsjstestPID" || true
 if ! wait "$wsjstestPID"; then
   echo "--- wsjstest exited unsuccessfully"
   echo "output:"

--- a/conn_common.go
+++ b/conn_common.go
@@ -211,21 +211,22 @@ func (c *Conn) setCloseErr(err error) {
 
 // See https://github.com/nhooyr/websocket/issues/153
 type atomicInt64 struct {
-	v atomic.Value
+	v int64
 }
 
 func (v *atomicInt64) Load() int64 {
-	i, ok := v.v.Load().(int64)
-	if !ok {
-		return 0
-	}
-	return i
+	return atomic.LoadInt64(&v.v)
 }
 
 func (v *atomicInt64) Store(i int64) {
-	v.v.Store(i)
+	atomic.StoreInt64(&v.v, i)
 }
 
 func (v *atomicInt64) String() string {
-	return fmt.Sprint(v.v.Load())
+	return fmt.Sprint(v.Load())
+}
+
+// Increment increments the value and returns the new value.
+func (v *atomicInt64) Increment(delta int64) int64 {
+	return atomic.AddInt64(&v.v, delta)
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -37,6 +37,10 @@ import (
 	"nhooyr.io/websocket/wspb"
 )
 
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
 func TestHandshake(t *testing.T) {
 	t.Parallel()
 
@@ -909,10 +913,6 @@ func TestConn(t *testing.T) {
 			c.Close(websocket.StatusNormalClosure, "")
 		})
 	}
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func testServer(tb testing.TB, fn func(w http.ResponseWriter, r *http.Request) error, tls bool) (s *httptest.Server, closeFn func()) {

--- a/frame_test.go
+++ b/frame_test.go
@@ -10,9 +10,14 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
 
 func randBool() bool {
 	return rand.Intn(1) == 0

--- a/handshake_test.go
+++ b/handshake_test.go
@@ -367,14 +367,17 @@ func Test_verifyServerHandshake(t *testing.T) {
 			resp := w.Result()
 
 			r := httptest.NewRequest("GET", "/", nil)
-			key := makeSecWebSocketKey()
+			key, err := makeSecWebSocketKey()
+			if err != nil {
+				t.Fatal(err)
+			}
 			r.Header.Set("Sec-WebSocket-Key", key)
 
 			if resp.Header.Get("Sec-WebSocket-Accept") == "" {
 				resp.Header.Set("Sec-WebSocket-Accept", secWebSocketAccept(key))
 			}
 
-			err := verifyServerResponse(r, resp)
+			err = verifyServerResponse(r, resp)
 			if (err == nil) != tc.success {
 				t.Fatalf("unexpected error: %+v", err)
 			}


### PR DESCRIPTION
math/rand was being used inappropiately and did not have
a init function for every file it was used in.

crypto/rand was also being used incorrectly within
makeSecWebSocketKey().
<!--
Please read the contributing guidelines.
https://github.com/nhooyr/websocket/blob/master/.github/CONTRIBUTING.md#pull-requests
-->