### PR TITLE
Undeprecate InsecureSkipVerify

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Advantages of nhooyr.io/websocket:
   - Gorilla's implementation is slower and uses [unsafe](https://golang.org/pkg/unsafe/).
 - Full [permessage-deflate](https://tools.ietf.org/html/rfc7692) compression extension support
   - Gorilla only supports no context takeover mode
-  - We use a vendored [klauspost/compress](https://github.com/klauspost/compress) for much lower memory usage ([gorilla/websocket#203](https://github.com/gorilla/websocket/issues/203))
+  - We use [klauspost/compress](https://github.com/klauspost/compress) for much lower memory usage ([gorilla/websocket#203](https://github.com/gorilla/websocket/issues/203))
 - [CloseRead](https://pkg.go.dev/nhooyr.io/websocket#Conn.CloseRead) helper ([gorilla/websocket#492](https://github.com/gorilla/websocket/issues/492))
 - Actively maintained ([gorilla/websocket#370](https://github.com/gorilla/websocket/issues/370))
 

--- a/accept.go
+++ b/accept.go
@@ -28,8 +28,7 @@ type AcceptOptions struct {
 
 	// InsecureSkipVerify is used to disable Accept's origin verification behaviour.
 	//
-	// Deprecated: Use OriginPatterns with a match all pattern of * instead to control
-	// origin authorization yourself.
+	// You probably want to use OriginPatterns instead.
 	InsecureSkipVerify bool
 
 	// OriginPatterns lists the host patterns for authorized origins.
@@ -46,6 +45,9 @@ type AcceptOptions struct {
 	//
 	// Please ensure you understand the ramifications of enabling this.
 	// If used incorrectly your WebSocket server will be open to CSRF attacks.
+	//
+	// Do not use * as a pattern to allow any origin, prefer to use InsecureSkipVerify instead
+	// to bring attention to the danger of such a setting.
 	OriginPatterns []string
 
 	// CompressionMode controls the compression mode.

--- a/conn_test.go
+++ b/conn_test.go
@@ -273,8 +273,8 @@ func TestWasm(t *testing.T) {
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-			Subprotocols:   []string{"echo"},
-			OriginPatterns: []string{"*"},
+			Subprotocols:       []string{"echo"},
+			InsecureSkipVerify: true,
 		})
 		if err != nil {
 			t.Errorf("echo server failed: %v", err)

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -17,8 +17,10 @@ Visit the printed URL to submit and view broadcasted messages in a browser.
 The frontend is contained in `index.html`, `index.js` and `index.css`. It sets up the
 DOM with a scrollable div at the top that is populated with new messages as they are broadcast.
 At the bottom it adds a form to submit messages.
+
 The messages are received via the WebSocket `/subscribe` endpoint and published via
-the HTTP POST `/publish` endpoint.
+the HTTP POST `/publish` endpoint. The reason for not publishing messages over the WebSocket
+is so that you can easily publish a message with curl.
 
 The server portion is `main.go` and `chat.go` and implements serving the static frontend
 assets, the `/subscribe` WebSocket endpoint and the HTTP POST `/publish` endpoint.


### PR DESCRIPTION
Should prefer it over AcceptOrigins with []string{"*"}
for explicitness.