### PR TITLE
Clone options

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -63,6 +63,14 @@ type AcceptOptions struct {
 	CompressionThreshold int
 }
 
+func (opts *AcceptOptions) cloneWithDefaults() *AcceptOptions {
+	var o AcceptOptions
+	if opts != nil {
+		o = *opts
+	}
+	return &o
+}
+
 // Accept accepts a WebSocket handshake from a client and upgrades the
 // the connection to a WebSocket.
 //
@@ -77,17 +85,13 @@ func Accept(w http.ResponseWriter, r *http.Request, opts *AcceptOptions) (*Conn,
 func accept(w http.ResponseWriter, r *http.Request, opts *AcceptOptions) (_ *Conn, err error) {
 	defer errd.Wrap(&err, "failed to accept WebSocket connection")
 
-	if opts == nil {
-		opts = &AcceptOptions{}
-	}
-	opts = &*opts
-
 	errCode, err := verifyClientRequest(w, r)
 	if err != nil {
 		http.Error(w, err.Error(), errCode)
 		return nil, err
 	}
 
+	opts = opts.cloneWithDefaults()
 	if !opts.InsecureSkipVerify {
 		err = authenticateOrigin(r, opts.OriginPatterns)
 		if err != nil {

--- a/dial.go
+++ b/dial.go
@@ -47,6 +47,20 @@ type DialOptions struct {
 	CompressionThreshold int
 }
 
+func (opts *DialOptions) cloneWithDefaults() *DialOptions {
+	var o DialOptions
+	if opts != nil {
+		o = *opts
+	}
+	if o.HTTPClient == nil {
+		o.HTTPClient = http.DefaultClient
+	}
+	if o.HTTPHeader == nil {
+		o.HTTPHeader = http.Header{}
+	}
+	return &o
+}
+
 // Dial performs a WebSocket handshake on url.
 //
 // The response is the WebSocket handshake response from the server.
@@ -67,17 +81,7 @@ func Dial(ctx context.Context, u string, opts *DialOptions) (*Conn, *http.Respon
 func dial(ctx context.Context, urls string, opts *DialOptions, rand io.Reader) (_ *Conn, _ *http.Response, err error) {
 	defer errd.Wrap(&err, "failed to WebSocket dial")
 
-	if opts == nil {
-		opts = &DialOptions{}
-	}
-
-	opts = &*opts
-	if opts.HTTPClient == nil {
-		opts.HTTPClient = http.DefaultClient
-	}
-	if opts.HTTPHeader == nil {
-		opts.HTTPHeader = http.Header{}
-	}
+	opts = opts.cloneWithDefaults()
 
 	secWebSocketKey, err := secWebSocketKey(rand)
 	if err != nil {


### PR DESCRIPTION
`opts = &*opts` is a no-op.

See: https://staticcheck.io/docs/checks#SA4001