### PR TITLE
removing bad newline

### DIFF
--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -16,7 +16,6 @@ import (
 // It ensures the client speaks the echo subprotocol and
 // only allows one message every 100ms with a 10 message burst.
 type echoServer struct {
-
 	// logf controls where logs are sent.
 	logf func(f string, v ...interface{})
 }


### PR DESCRIPTION
this seems like a pointless newline, correct me if I am wrong.

furthermore, I would recommend using [wsl](https://github.com/bombsimon/wsl) in CI to automatically detect these kinds of errors in the future.
wsl is included in [golangci-lint](https://golangci-lint.run/usage/linters/), which is the defacto golang linter, which it seems like you [don't use currently](https://github.com/nhooyr/websocket/blob/master/ci/lint.sh).