### PR TITLE
Addition of options to allow loading of custom certificates

### DIFF
--- a/internal/wsjs/wsjs_js.go
+++ b/internal/wsjs/wsjs_js.go
@@ -27,7 +27,7 @@ func handleJSError(err *error, onErr func()) {
 }
 
 // New is a wrapper around the javascript WebSocket constructor.
-func New(url string, protocols []string) (c WebSocket, err error) {
+func New(url string, protocols []string, options map[string]interface{}) (c WebSocket, err error) {
 	defer handleJSError(&err, func() {
 		c = WebSocket{}
 	})
@@ -38,7 +38,7 @@ func New(url string, protocols []string) (c WebSocket, err error) {
 	}
 
 	c = WebSocket{
-		v: js.Global().Get("WebSocket").New(url, jsProtocols),
+		v: js.Global().Get("WebSocket").New(url, jsProtocols, options),
 	}
 
 	c.setBinaryType("arraybuffer")

--- a/ws_js.go
+++ b/ws_js.go
@@ -237,6 +237,7 @@ func (c *Conn) Subprotocol() string {
 type DialOptions struct {
 	// Subprotocols lists the subprotocols to negotiate with the server.
 	Subprotocols []string
+	Options 	 map[string]interface{}
 }
 
 // Dial creates a new WebSocket connection to the given url with the given options.
@@ -259,7 +260,7 @@ func dial(ctx context.Context, url string, opts *DialOptions) (*Conn, *http.Resp
 	url = strings.Replace(url, "http://", "ws://", 1)
 	url = strings.Replace(url, "https://", "wss://", 1)
 
-	ws, err := wsjs.New(url, opts.Subprotocols)
+	ws, err := wsjs.New(url, opts.Subprotocols, opts.Options)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Addition of an Options field of type map[string]interface{} to DialOptions which is used in the constructor for the js websocket instance and enables passing custom options like custom certificates.