### PR TITLE
Fix DOS attack from malicious pongs

### DIFF
--- a/ci/container/Dockerfile
+++ b/ci/container/Dockerfile
@@ -10,5 +10,5 @@ RUN go get golang.org/x/tools/cmd/stringer
 RUN go get golang.org/x/lint/golint
 RUN go get github.com/agnivade/wasmbrowsertest
 
-RUN npm install -g prettier
-RUN npm install -g netlify-cli
+RUN npm --unsafe-perm=true install -g prettier
+RUN npm --unsafe-perm=true install -g netlify-cli

--- a/conn_notjs.go
+++ b/conn_notjs.go
@@ -189,7 +189,7 @@ func (c *Conn) Ping(ctx context.Context) error {
 }
 
 func (c *Conn) ping(ctx context.Context, p string) error {
-	pong := make(chan struct{})
+	pong := make(chan struct{}, 1)
 
 	c.activePingsMu.Lock()
 	c.activePings[p] = pong

--- a/read.go
+++ b/read.go
@@ -271,7 +271,10 @@ func (c *Conn) handleControl(ctx context.Context, h header) (err error) {
 		pong, ok := c.activePings[string(b)]
 		c.activePingsMu.Unlock()
 		if ok {
-			close(pong)
+			select {
+			case pong <- struct{}{}:
+			default:
+			}
 		}
 		return nil
 	}


### PR DESCRIPTION
A double channel close panic was possible if a peer sent back multiple
pongs for every ping.

If the second pong arrived before the ping goroutine deleted its channel
from the map, the channel would be closed twice and so a panic would
ensue.

This fixes that by having the read goroutine send on the ping
goroutine's channel rather than closing it.

Reported via email by Tibor Kálmán @kalmant

Please update to the new release ASAP!

cc @noramehesz