### PR TITLE
Returns real remote and local address instead mocked

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -155,8 +155,8 @@ func TestConn(t *testing.T) {
 		n1.SetDeadline(time.Time{})
 
 		assert.Equal(t, "remote addr", n1.RemoteAddr(), n1.LocalAddr())
-		assert.Equal(t, "remote addr string", "websocket/unknown-addr", n1.RemoteAddr().String())
-		assert.Equal(t, "remote addr network", "websocket", n1.RemoteAddr().Network())
+		assert.Equal(t, "remote addr string", "pipe", n1.RemoteAddr().String())
+		assert.Equal(t, "remote addr network", "pipe", n1.RemoteAddr().Network())
 
 		errs := xsync.Go(func() error {
 			_, err := n2.Write([]byte("hello"))

--- a/netconn.go
+++ b/netconn.go
@@ -33,8 +33,13 @@ import (
 // where only the reading/writing goroutines are interrupted but the connection
 // is kept alive.
 //
-// The Addr methods will return a mock net.Addr that returns "websocket" for Network
-// and "websocket/unknown-addr" for String.
+// The Addr methods will return the real addresses for connections obtained
+// from websocket.Accept. But for connections obtained from websocket.Dial, a mock net.Addr
+// will be returned that gives "websocket" for Network() and "websocket/unknown-addr" for
+// String(). This is because websocket.Dial only exposes a io.ReadWriteCloser instead of the
+// full net.Conn to us.
+//
+// When running as WASM, the Addr methods will always return the mock address described above.
 //
 // A received StatusNormalClosure or StatusGoingAway close frame will be translated to
 // io.EOF when reading.
@@ -179,14 +184,6 @@ func (a websocketAddr) Network() string {
 
 func (a websocketAddr) String() string {
 	return "websocket/unknown-addr"
-}
-
-func (nc *netConn) RemoteAddr() net.Addr {
-	return websocketAddr{}
-}
-
-func (nc *netConn) LocalAddr() net.Addr {
-	return websocketAddr{}
 }
 
 func (nc *netConn) SetDeadline(t time.Time) error {

--- a/netconn_js.go
+++ b/netconn_js.go
@@ -1,0 +1,11 @@
+package websocket
+
+import "net"
+
+func (nc *netConn) RemoteAddr() net.Addr {
+	return websocketAddr{}
+}
+
+func (nc *netConn) LocalAddr() net.Addr {
+	return websocketAddr{}
+}

--- a/netconn_notjs.go
+++ b/netconn_notjs.go
@@ -1,0 +1,20 @@
+//go:build !js
+// +build !js
+
+package websocket
+
+import "net"
+
+func (nc *netConn) RemoteAddr() net.Addr {
+	if unc, ok := nc.c.rwc.(net.Conn); ok {
+		return unc.RemoteAddr()
+	}
+	return websocketAddr{}
+}
+
+func (nc *netConn) LocalAddr() net.Addr {
+	if unc, ok := nc.c.rwc.(net.Conn); ok {
+		return unc.LocalAddr()
+	}
+	return websocketAddr{}
+}


### PR DESCRIPTION
Currently, RemoteAddr() and LocalAddr() are mocked. This change allow the real RemoteAddr() and LocalAddr() to be used.