### PR TITLE
Use net.ErrClosed

### DIFF
--- a/close.go
+++ b/close.go
@@ -119,15 +119,13 @@ func (c *Conn) closeHandshake(code StatusCode, reason string) (err error) {
 	return nil
 }
 
-var errAlreadyWroteClose = errors.New("already wrote close")
-
 func (c *Conn) writeClose(code StatusCode, reason string) error {
 	c.closeMu.Lock()
 	wroteClose := c.wroteClose
 	c.wroteClose = true
 	c.closeMu.Unlock()
 	if wroteClose {
-		return errAlreadyWroteClose
+		return errClosed
 	}
 
 	ce := CloseError{

--- a/close_go113.go
+++ b/close_go113.go
@@ -1,0 +1,9 @@
+// +build !go1.16
+
+package websocket
+
+import (
+	"errors"
+)
+
+var errClosed = errors.New("use of closed network connection")

--- a/close_go116.go
+++ b/close_go116.go
@@ -1,0 +1,9 @@
+// +build go1.16
+
+package websocket
+
+import (
+	"net"
+)
+
+var errClosed = net.ErrClosed


### PR DESCRIPTION
Go 1.16 has introduced net.ErrClosed, which should be returned/wrapped when an
I/O call is performed on a network connection which has already been closed.
This is useful to avoid cluttering logs with messages like "failed to close
WebSocket: already wrote close".

Closes: https://github.com/nhooyr/websocket/issues/286