### PR TITLE
Fix close writing even if context is cancelled

### DIFF
--- a/close_notjs.go
+++ b/close_notjs.go
@@ -73,7 +73,7 @@ func (c *Conn) writeClose(code StatusCode, reason string) error {
 		}
 	}
 
-	writeErr := c.writeControl(context.Background(), opClose, p)
+	writeErr := c.writeControl(c.msgWriterState.ctx, opClose, p)
 	if CloseStatus(writeErr) != -1 {
 		// Not a real error if it's due to a close frame being received.
 		writeErr = nil


### PR DESCRIPTION
In an HTTP handler where the context is used for cleanup, a goroutine would leak temporarily. By using the write context, it should block the WebSocket from sending the close frame at all if cancelled.