### PR TITLE
Extend DialOptions to allow Host header override

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -30,6 +30,10 @@ type DialOptions struct {
 	// HTTPHeader specifies the HTTP headers included in the handshake request.
 	HTTPHeader http.Header
 
+	// Host optionally overrides the Host HTTP header to send. If empty, the value
+	// of URL.Host will be used.
+	Host string
+
 	// Subprotocols lists the WebSocket subprotocols to negotiate with the server.
 	Subprotocols []string
 
@@ -167,6 +171,9 @@ func handshakeRequest(ctx context.Context, urls string, opts *DialOptions, copts
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create new http request: %w", err)
+	}
+	if len(opts.Host) > 0 {
+		req.Host = opts.Host
 	}
 	req.Header = opts.HTTPHeader.Clone()
 	req.Header.Set("Connection", "Upgrade")


### PR DESCRIPTION
The standard `http.Request.Host` field allows to override the `Host` header that is sent with the HTTP request (`URL.Host` is used by default). Such option can be useful in various scenarios, for example when running behind some proxy server.

This patch extends the `DialOptions` struct with `Host` field that basically does the same.