### PR TITLE
Fix dial panic when ctx is nil

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -159,7 +159,7 @@ func handshakeRequest(ctx context.Context, urls string, opts *DialOptions, copts
 
 	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to build HTTP request: %w", err)
+		return nil, fmt.Errorf("http.NewRequestWithContext failed: %w", err)
 	}
 	req.Header = opts.HTTPHeader.Clone()
 	req.Header.Set("Connection", "Upgrade")

--- a/dial.go
+++ b/dial.go
@@ -157,7 +157,10 @@ func handshakeRequest(ctx context.Context, urls string, opts *DialOptions, copts
 		return nil, fmt.Errorf("unexpected url scheme: %q", u.Scheme)
 	}
 
-	req, _ := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build HTTP request: %w", err)
+	}
 	req.Header = opts.HTTPHeader.Clone()
 	req.Header.Set("Connection", "Upgrade")
 	req.Header.Set("Upgrade", "websocket")

--- a/dial_test.go
+++ b/dial_test.go
@@ -23,10 +23,11 @@ func TestBadDials(t *testing.T) {
 		t.Parallel()
 
 		testCases := []struct {
-			name string
-			url  string
-			opts *DialOptions
-			rand readerFunc
+			name   string
+			url    string
+			opts   *DialOptions
+			rand   readerFunc
+			nilCtx bool
 		}{
 			{
 				name: "badURL",
@@ -46,6 +47,11 @@ func TestBadDials(t *testing.T) {
 					return 0, io.EOF
 				},
 			},
+			{
+				name:   "nilContext",
+				url:    "http://localhost",
+				nilCtx: true,
+			},
 		}
 
 		for _, tc := range testCases {
@@ -53,8 +59,12 @@ func TestBadDials(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				defer cancel()
+				var ctx context.Context
+				var cancel func()
+				if !tc.nilCtx {
+					ctx, cancel = context.WithTimeout(context.Background(), time.Second*5)
+					defer cancel()
+				}
 
 				if tc.rand == nil {
 					tc.rand = rand.Reader.Read


### PR DESCRIPTION
When the ctx is nil, http.NewRequestWithContext returns a "net/http: nil Context" error and a nil request. In this case, the dial function panics because it assumes the req is never nil. This checks the returning error and returns it, so that callers get an error instead of a panic in that scenario.