### PR TITLE
Change protocol in docs and logs from http to ws

### DIFF
--- a/internal/examples/chat/README.md
+++ b/internal/examples/chat/README.md
@@ -5,7 +5,7 @@ This directory contains a full stack example of a simple chat webapp using nhooy
 ```bash
 $ cd examples/chat
 $ go run . localhost:0
-listening on http://127.0.0.1:51055
+listening on ws://127.0.0.1:51055
 ```
 
 Visit the printed URL to submit and view broadcasted messages in a browser.

--- a/internal/examples/chat/main.go
+++ b/internal/examples/chat/main.go
@@ -31,7 +31,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("listening on http://%v", l.Addr())
+	log.Printf("listening on ws://%v", l.Addr())
 
 	cs := newChatServer()
 	s := &http.Server{

--- a/internal/examples/echo/README.md
+++ b/internal/examples/echo/README.md
@@ -5,7 +5,7 @@ This directory contains a echo server example using nhooyr.io/websocket.
 ```bash
 $ cd examples/echo
 $ go run . localhost:0
-listening on http://127.0.0.1:51055
+listening on ws://127.0.0.1:51055
 ```
 
 You can use a WebSocket client like https://github.com/hashrocket/ws to connect. All messages

--- a/internal/examples/echo/main.go
+++ b/internal/examples/echo/main.go
@@ -31,7 +31,7 @@ func run() error {
 	if err != nil {
 		return err
 	}
-	log.Printf("listening on http://%v", l.Addr())
+	log.Printf("listening on ws://%v", l.Addr())
 
 	s := &http.Server{
 		Handler: echoServer{


### PR DESCRIPTION
the websocket protocol require the protocol on the url to be `ws` not `http`, then we must log the url which is for websocket.