### PR TITLE
Provide a simple callback function for when you need to know a ping came in.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -79,6 +79,8 @@ type Conn struct {
 	pingCounter   int32
 	activePingsMu sync.Mutex
 	activePings   map[string]chan<- struct{}
+
+	pingCallback func()
 }
 
 type connConfig struct {
@@ -249,6 +251,13 @@ func (c *Conn) ping(ctx context.Context, p string) error {
 	case <-pong:
 		return nil
 	}
+}
+
+// SetPingCallback sets a callback that is called when a ping is received.
+// The callback is called synchronously from the Reader goroutine and must
+// not block.
+func (c *Conn) SetPingCallback(cb func()) {
+	c.pingCallback = cb
 }
 
 type mu struct {

--- a/read.go
+++ b/read.go
@@ -294,6 +294,9 @@ func (c *Conn) handleControl(ctx context.Context, h header) (err error) {
 
 	switch h.opcode {
 	case opPing:
+		if c.pingCallback != nil {
+			c.pingCallback()
+		}
 		return c.writeControl(ctx, opPong, b)
 	case opPong:
 		c.activePingsMu.Lock()


### PR DESCRIPTION
This is a simple approach to providing users with a relatively easy and safe way to be notified of when a `ping` comes from the server to the client.  It doesn't allow for any action to be take aside from letting 3rd party code know something happened.

This should address #246.