### PR TITLE
Fix unaligned load error on 32-bit architectures

### DIFF
--- a/netconn.go
+++ b/netconn.go
@@ -94,6 +94,8 @@ func NetConn(ctx context.Context, c *Conn, msgType MessageType) net.Conn {
 }
 
 type netConn struct {
+    // These must be first to be aligned on 32 bit platforms.
+	// https://github.com/nhooyr/websocket/pull/438
 	readExpired  int64
 	writeExpired int64
 

--- a/netconn.go
+++ b/netconn.go
@@ -94,22 +94,23 @@ func NetConn(ctx context.Context, c *Conn, msgType MessageType) net.Conn {
 }
 
 type netConn struct {
+	readExpired  int64
+	writeExpired int64
+
 	c       *Conn
 	msgType MessageType
 
-	writeTimer   *time.Timer
-	writeMu      *mu
-	writeExpired int64
-	writeCtx     context.Context
-	writeCancel  context.CancelFunc
+	writeTimer  *time.Timer
+	writeMu     *mu
+	writeCtx    context.Context
+	writeCancel context.CancelFunc
 
-	readTimer   *time.Timer
-	readMu      *mu
-	readExpired int64
-	readCtx     context.Context
-	readCancel  context.CancelFunc
-	readEOFed   bool
-	reader      io.Reader
+	readTimer  *time.Timer
+	readMu     *mu
+	readCtx    context.Context
+	readCancel context.CancelFunc
+	readEOFed  bool
+	reader     io.Reader
 }
 
 var _ net.Conn = &netConn{}


### PR DESCRIPTION
On some 32-bit architectures, 64-bit atomic operations panic when the value is not aligned properly.

In this package, this causes netConn operations to panic when compiling with `GOARCH=386`, since netConn does atomic operations with int64 values in the netConn struct (namely, with readExpired and writeExpired):

```
runtime/internal/atomic.panicUnaligned()
        .../go1.22/src/runtime/internal/atomic/unaligned.go:8 +0x2d
runtime/internal/atomic.Load64(0x90a011c)
        .../go1.22/src/runtime/internal/atomic/atomic_386.s:225 +0x10
nhooyr.io/websocket.(*netConn).read(0x90a00f0, {0x9180000, 0x8000, 0x8000})
        .../go/pkg/mod/nhooyr.io/websocket@v1.8.10/netconn.go:157 +0x2a
nhooyr.io/websocket.(*netConn).Read(0x90a00f0, {0x9180000, 0x8000, 0x8000})
        .../go/pkg/mod/nhooyr.io/websocket@v1.8.10/netconn.go:145 +0xb1

!!!REST OF THE CALLSTACK SNIPPED!!!
```

This commit fixes this by moving readExpired and writeExpired to the beginning of the struct, which makes them properly aligned.

I didn't test, but I think this error will also occur on 32-bit ARM (Raspberry Pi Zero) and MIPS32 (a bunch of routers use that, which is a real use case for me), see https://pkg.go.dev/sync/atomic#pkg-note-BUG and https://github.com/grafana/loki/issues/6944