### PR TITLE
feat: introduces an option for a custom body size in websocket.Dial function

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -160,7 +160,7 @@ func dial(ctx context.Context, urls string, opts *DialOptions, rand io.Reader) (
 	respBody := resp.Body
 	resp.Body = nil
 	defer func() {
-		if err != nil {
+		if err != nil && respBody != nil {
 			// Capture a limited portion of the response body for easier debugging,
 			// following the limit configured by MaxErrorResponseBodyBytes.
 			limit := opts.MaxErrorResponseBodyBytes

--- a/dial_test.go
+++ b/dial_test.go
@@ -515,3 +515,35 @@ func TestDial_ErrorResponseBodyCapture_Disabled_NoBodyWithClose(t *testing.T) {
 		t.Fatal("expected original body to be closed")
 	}
 }
+
+func TestDial_ErrorResponseBodyCapture_NilBody(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	rt := func(r *http.Request) (*http.Response, error) {
+		// No body returned; ensure Dial does not panic when attempting capture.
+		return &http.Response{
+			StatusCode: http.StatusForbidden,
+			Body:       nil,
+		}, nil
+	}
+
+	_, resp, err := websocket.Dial(ctx, "ws://example.com", &websocket.DialOptions{
+		HTTPClient: mockHTTPClient(rt),
+	})
+	assert.Error(t, err)
+	if resp == nil {
+		t.Fatal("expected non-nil resp")
+	}
+	assert.Equal(t, "StatusCode", http.StatusForbidden, resp.StatusCode)
+	if resp.Body == nil {
+		return
+	}
+	b, rerr := io.ReadAll(resp.Body)
+	assert.Success(t, rerr)
+	if len(b) != 0 {
+		t.Fatalf("expected empty body when original body is nil, got %d bytes", len(b))
+	}
+}


### PR DESCRIPTION
#### Why

Feature asked by this issue:
- https://github.com/coder/websocket/issues/528

 #### What

  - Introduce `DialOptions.MaxErrorResponseBodyBytes` so callers can opt into more (or zero) error-body
    bytes when the handshake fails, enabling better branching on status/body while keeping the default
    1024-byte limit.
  - Preserve existing success-path behavior and safety: response bodies stay nil on success; 3s timeout
    still guards error-body reads; disabled option closes without reading.

  #### Key Changes

  - dial.go: use new option to bound error-body capture; skip capture if set < 0; guard nil bodies;
    still close original body with 3s fail-safe.
  - dial_test.go: new/updated tests covering default cap, custom cap, disabled capture (ensures close),
    status code presence, and nil-body safety.

#### Testing
I did some testing with a dummy server responding a fixed status 400 and a 1mb body:
<img width="630" height="676" alt="image" src="https://github.com/user-attachments/assets/52fa28e3-a573-4bed-9883-72311834810b" />

<img width="1282" height="250" alt="image" src="https://github.com/user-attachments/assets/c99d722e-1c90-4479-a975-824bf380078d" />

