### PR TITLE
ci: remove dev branch jobs and add static.sh

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -34,33 +34,3 @@ jobs:
         with:
           name: coverage.html
           path: ./ci/out/coverage.html
-  bench-dev:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: dev
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-      - run: AUTOBAHN=1 make bench
-  test-dev:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Disable AppArmor
-        if: runner.os == 'Linux'
-        run: |
-          # Disable AppArmor for Ubuntu 23.10+.
-          # https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-          echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
-      - uses: actions/checkout@v4
-        with:
-          ref: dev
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-      - run: AUTOBAHN=1 make test
-      - uses: actions/upload-artifact@v4
-        with:
-          name: coverage-dev.html
-          path: ./ci/out/coverage.html

--- a/ci/static.sh
+++ b/ci/static.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eu
+
+cd -- "$(dirname "$0")/.."
+
+if [[ ! -f ./ci/out/profile.txt ]]; then
+	echo "No coverage profile found, run 'make test' first"
+	exit 1
+fi
+
+if [[ ! -f ./ci/out/coverage.html ]]; then
+	echo "No coverage report found, run 'make test' first"
+	exit 1
+fi
+
+rm -rf ./ci/out/static
+mkdir -p ./ci/out/static
+cp ./ci/out/coverage.html ./ci/out/static/coverage.html
+percent=$(go tool cover -func ./ci/out/profile.txt | tail -n1 | awk '{print $3}' | tr -d '%')
+wget -O ./ci/out/static/coverage.svg "https://img.shields.io/badge/coverage-${percent}%25-success"


### PR DESCRIPTION
Remove bench-dev and test-dev jobs from daily workflow since the dev
branch no longer exists.

Add ci/static.sh script to generate coverage badge for GitHub Pages.

Refs #539
