### PR TITLE
fix(dial): verify HTTP/1.x protocol in verifyServerResponseH1

### DIFF
--- a/dial.go
+++ b/dial.go
@@ -328,6 +328,10 @@ func verifyServerResponse(opts *DialOptions, copts *compressionOptions, secWebSo
 }
 
 func verifyServerResponseH1(opts *DialOptions, copts *compressionOptions, secWebSocketKey string, resp *http.Response) (*compressionOptions, error) {
+	if resp.ProtoMajor != 1 {
+		return nil, fmt.Errorf("expected HTTP/1.x response but got: %s", resp.Proto)
+	}
+
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		return nil, fmt.Errorf("expected handshake response status code %v but got %v", http.StatusSwitchingProtocols, resp.StatusCode)
 	}


### PR DESCRIPTION
Add resp.ProtoMajor check in verifyServerResponseH1 for consistency
with verifyServerResponseH2 which already performs this check.

Refs #539
