### PR TITLE
fix: do not wrap io.EOF in errd.Wrap

### DIFF
--- a/internal/errd/wrap.go
+++ b/internal/errd/wrap.go
@@ -2,13 +2,16 @@ package errd
 
 import (
 	"fmt"
+	"io"
 )
 
 // Wrap wraps err with fmt.Errorf if err is non nil.
 // Intended for use with defer and a named error return.
 // Inspired by https://github.com/golang/go/issues/32676.
+//
+// io.EOF is never wrapped because callers test for it with ==.
 func Wrap(err *error, f string, v ...any) {
-	if *err != nil {
+	if *err != nil && *err != io.EOF {
 		*err = fmt.Errorf(f+": %w", append(v, *err)...)
 	}
 }


### PR DESCRIPTION
Fixes #561

## Problem

The `errd.Wrap` helper wraps all non-nil errors using `fmt.Errorf("%w")`. When `io.EOF` is returned (e.g. from `Conn.reader`), it becomes `"failed to get reader: EOF"`. Per Go convention, `io.EOF` must never be wrapped:

> EOF is the error returned by Read when no more input is available.
> (Read must return EOF itself, not an error wrapping EOF,
> because callers will test for EOF using ==.)

This breaks callers like `io.Copy` and `bufio.Scanner` that test `err == io.EOF`.

## Fix

Skip wrapping in `errd.Wrap` when the error is exactly `io.EOF`:

```go
func Wrap(err *error, f string, v ...any) {
    if *err != nil && *err != io.EOF {
        *err = fmt.Errorf(f+": %w", append(v, *err)...)
    }
}
```