### PR TITLE
fix: suppress net.ErrClosed on concurrent Close

### DIFF
--- a/close.go
+++ b/close.go
@@ -99,11 +99,7 @@ func CloseStatus(err error) StatusCode {
 func (c *Conn) Close(code StatusCode, reason string) (err error) {
 	defer errd.Wrap(&err, "failed to close WebSocket")
 
-	if c.casClosing() {
-		err = c.waitGoroutines()
-		if err != nil {
-			return err
-		}
+	if c.userClosed.Swap(true) && c.isClosed() {
 		return net.ErrClosed
 	}
 	defer func() {
@@ -111,6 +107,10 @@ func (c *Conn) Close(code StatusCode, reason string) (err error) {
 			err = nil
 		}
 	}()
+
+	if c.casClosing() {
+		return c.waitGoroutines()
+	}
 
 	err = c.closeHandshake(code, reason)
 
@@ -132,11 +132,7 @@ func (c *Conn) Close(code StatusCode, reason string) (err error) {
 func (c *Conn) CloseNow() (err error) {
 	defer errd.Wrap(&err, "failed to immediately close WebSocket")
 
-	if c.casClosing() {
-		err = c.waitGoroutines()
-		if err != nil {
-			return err
-		}
+	if c.userClosed.Swap(true) && c.isClosed() {
 		return net.ErrClosed
 	}
 	defer func() {
@@ -144,6 +140,10 @@ func (c *Conn) CloseNow() (err error) {
 			err = nil
 		}
 	}()
+
+	if c.casClosing() {
+		return c.waitGoroutines()
+	}
 
 	err = c.close()
 

--- a/conn.go
+++ b/conn.go
@@ -77,9 +77,10 @@ type Conn struct {
 	closeReadCtx  context.Context
 	closeReadDone chan struct{}
 
-	closing atomic.Bool
-	closeMu sync.Mutex // Protects following.
-	closed  chan struct{}
+	userClosed atomic.Bool // Set by Close/CloseNow on first user call.
+	closing    atomic.Bool
+	closeMu    sync.Mutex // Protects following.
+	closed     chan struct{}
 
 	pingCounter    atomic.Int64
 	activePingsMu  sync.Mutex


### PR DESCRIPTION
Close and CloseNow returned a wrapped `net.ErrClosed` when the internal read loop or write path won the `casClosing` race before the user-facing call. The defer that suppresses `net.ErrClosed` was only registered on the CAS winner path, so the first user call to Close could surface "use of closed network connection" even though the close completed successfully.

This separates user-facing close tracking (`userClosed` atomic) from internal close coordination (`casClosing`). Combined with `isClosed`, this gives three distinct behaviors:

- First user call, close in progress or peer already closed: `nil`.
- Concurrent user calls while close is in progress: `nil`, returns instantly without blocking.
- User call after close has fully completed: `net.ErrClosed`.

Refs coder/internal#1541

> 🤖 This PR was created with the help of Coder Agents, and _will be_ reviewed by a human. 🏂🏻