### PR TITLE
avoid per-frame cleanup closures on read to remove 2 allocs per frame read

### DIFF
--- a/read.go
+++ b/read.go
@@ -217,51 +217,48 @@ func (c *Conn) readLoop(ctx context.Context) (header, error) {
 	}
 }
 
-// prepareRead sets the readTimeout context and returns a done function
-// to be called after the read is done. It also returns an error if the
-// connection is closed. The reference to the error is used to assign
-// an error depending on if the connection closed or the context timed
-// out during use. Typically, the referenced error is a named return
-// variable of the function calling this method.
-func (c *Conn) prepareRead(ctx context.Context, err *error) (func(), error) {
+// prepareRead sets the read timeout and checks whether the connection is closed.
+func (c *Conn) prepareRead(ctx context.Context) error {
 	select {
 	case <-c.closed:
-		return nil, net.ErrClosed
+		return net.ErrClosed
 	default:
 	}
 	c.setupReadTimeout(ctx)
-
-	done := func() {
-		c.clearReadTimeout()
-		select {
-		case <-c.closed:
-			if *err != nil {
-				*err = net.ErrClosed
-			}
-		default:
-		}
-		if *err != nil && ctx.Err() != nil {
-			*err = ctx.Err()
-		}
-	}
 
 	c.closeStateMu.Lock()
 	closeReceivedErr := c.closeReceivedErr
 	c.closeStateMu.Unlock()
 	if closeReceivedErr != nil {
-		defer done()
-		return nil, closeReceivedErr
+		c.clearReadTimeout()
+		return closeReceivedErr
 	}
 
-	return done, nil
+	return nil
+}
+
+// finishRead clears the read timeout and reports whether the connection or
+// operation context ended while the read was in progress.
+func (c *Conn) finishRead(ctx context.Context, err *error) {
+	c.clearReadTimeout()
+	select {
+	case <-c.closed:
+		if *err != nil {
+			*err = net.ErrClosed
+		}
+	default:
+	}
+	if *err != nil && ctx.Err() != nil {
+		*err = ctx.Err()
+	}
 }
 
 func (c *Conn) readFrameHeader(ctx context.Context) (_ header, err error) {
-	readDone, err := c.prepareRead(ctx, &err)
+	err = c.prepareRead(ctx)
 	if err != nil {
 		return header{}, err
 	}
-	defer readDone()
+	defer c.finishRead(ctx, &err)
 
 	h, err := readFrameHeader(c.br, c.readHeaderBuf[:])
 	if err != nil {
@@ -272,11 +269,11 @@ func (c *Conn) readFrameHeader(ctx context.Context) (_ header, err error) {
 }
 
 func (c *Conn) readFramePayload(ctx context.Context, p []byte) (_ int, err error) {
-	readDone, err := c.prepareRead(ctx, &err)
+	err = c.prepareRead(ctx)
 	if err != nil {
 		return 0, err
 	}
-	defer readDone()
+	defer c.finishRead(ctx, &err)
 
 	n, err := io.ReadFull(c.br, p)
 	if err != nil {


### PR DESCRIPTION
Replace the per-frame cleanup closure returned by `prepareRead` with a normal `finishRead` method.

The closure captured the connection, context, and caller’s named error result. Escape analysis showed that both the closure and error result moved to the heap on every frame header and payload read. The new method preserves timeout cleanup and error mapping without those allocations.

This is admittedly a micro optimization but I decided to hunt out any allocation wins I can get in the direct request path for a project I'm working on, and assessed that the fixes were maintainable and easy to understand.

**AI disclosure:** I used AI to help find and fix this, but fully understand the problem myself and reviewed the code. The final shape contains manual adaptations, too. 

## Benchmarks

Each frame read removes 2 allocations and 64 bytes:

| Benchmark | Before | After | Change |
|---|---:|---:|---:|
| Header, background context | 170.5 ns, 216 B, 6 allocs | 118.5 ns, 152 B, 4 allocs | -30.5% time |
| Header, cancelable context | 211.1 ns, 216 B, 6 allocs | 158.7 ns, 152 B, 4 allocs | -24.8% time |
| `BenchmarkConn/disabledCompress` | 3.875 µs, 1536 B, 42 allocs | 3.657 µs, 1216 B, 32 allocs | -5.63% time, -20.83% bytes, -23.81% allocs |

The focused frame benchmarks used a temporary in-package harness and are not included in this change. I didn't think you'd want them in the repo cause they're such a micro optimization.